### PR TITLE
changed output file to show windows vm ip as well

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,7 @@ output "public_ip_address" {
 
 
 output "virtual_machine_id" {
-  value       = join("", azurerm_linux_virtual_machine.default.*.id)
+  value       = azurerm_linux_virtual_machine.default.*.id != null ? join("", azurerm_linux_virtual_machine.default.*.id) : join("", azurerm_virtual_machine.default.*.id) 
   description = "The ID of the Virtual Machine."
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,7 @@ output "public_ip_address" {
 
 
 output "virtual_machine_id" {
-  value       = azurerm_linux_virtual_machine.default.*.id != null ? join("", azurerm_linux_virtual_machine.default.*.id) : join("", azurerm_virtual_machine.default.*.id) 
+  value       = azurerm_linux_virtual_machine.default.*.id != null ? join("", azurerm_linux_virtual_machine.default.*.id) : join("", azurerm_virtual_machine.default.*.id)
   description = "The ID of the Virtual Machine."
 }
 


### PR DESCRIPTION
## what
* Added condition in the output file to send windows VM IP if it is creating before that only linux VM IP is working.

## why
* Module was not able to output linux VM IP in output.tf file.

## references
* Logic and self updated.
