### PR TITLE
fixed setting variable default issue

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -907,6 +907,7 @@ variable "auto_upgrade_minor_version" {
 }
 
 variable "settings" {
+  default     = null
   description = "The settings passed to the extension, these are specified as a JSON object in a string."
 }
 


### PR DESCRIPTION
## what
* Fixed the virtual machine's setting variable default value.

## why
* It was creating an issue while not passing a setting value in the module parameter while creating it.

## references
* Link to any supporting jira issues or helpful documentation to add some context (e.g. stackoverflow).
* Use `closes #123`, if this PR closes a Jira issue `#123`
