### PR TITLE
Feature 53

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -374,7 +374,7 @@ resource "azurerm_managed_disk" "data_disk" {
     }
   }
 
-  name                   = format("%s-managed-disk", each.value.data_disk.name)
+  name                   = format("%s-%s-managed-disk",module.labels.id, each.value.data_disk.name)
   resource_group_name    = var.resource_group_name
   location               = var.location
   storage_account_type   = lookup(each.value.data_disk, "storage_account_type", "StandardSSD_LRS")

--- a/main.tf
+++ b/main.tf
@@ -374,7 +374,7 @@ resource "azurerm_managed_disk" "data_disk" {
     }
   }
 
-  name                   = format("%s-%s-managed-disk",module.labels.id, each.value.data_disk.name)
+  name                   = format("%s-%s-managed-disk", module.labels.id, each.value.data_disk.name)
   resource_group_name    = var.resource_group_name
   location               = var.location
   storage_account_type   = lookup(each.value.data_disk, "storage_account_type", "StandardSSD_LRS")

--- a/main.tf
+++ b/main.tf
@@ -326,7 +326,7 @@ resource "azurerm_role_assignment" "azurerm_disk_encryption_set_key_vault_access
 
 resource "azurerm_key_vault_key" "example" {
   count        = var.enabled && var.enable_disk_encryption_set ? var.machine_count : 0
-  name         = var.vm_addon_name ? format("vm-%s-vault-key-%s", module.labels.id, count.index + 1) : format("vm-%s-vault-key-%s", module.labels.id, var.vm_addon_name)
+  name         = var.vm_addon_name == null ? format("vm-%s-vault-key-%s", module.labels.id, count.index + 1) : format("vm-%s-vault-key-%s", module.labels.id, var.vm_addon_name)
   key_vault_id = var.key_vault_id
   key_type     = "RSA"
   key_size     = 2048
@@ -345,8 +345,8 @@ resource "azurerm_key_vault_access_policy" "main" {
 
   key_vault_id = var.key_vault_id
 
-  tenant_id = azurerm_disk_encryption_set.example.*.identity.0.tenant_id
-  object_id = azurerm_disk_encryption_set.example.*.identity.0.principal_id
+  tenant_id = azurerm_disk_encryption_set.example[0].identity.0.tenant_id
+  object_id = azurerm_disk_encryption_set.example[0].identity.0.principal_id
   key_permissions = [
     "Create",
     "Delete",
@@ -374,7 +374,7 @@ resource "azurerm_managed_disk" "data_disk" {
     }
   }
 
-  name                   = each.value.data_disk.name
+  name                   = format("%s-managed-disk", each.value.data_disk.name)
   resource_group_name    = var.resource_group_name
   location               = var.location
   storage_account_type   = lookup(each.value.data_disk, "storage_account_type", "StandardSSD_LRS")


### PR DESCRIPTION
## what
* Updated the Managed Disk name format for virtual machine.
* Fixed the naming condition variable issue where condition was wrong, so fixed that.

## why
* Naming was directly assigned to the disk and format was not good so did that.
* In the key vault's key resource, identity and object id was passing as a object and string was required. so changed it so that error may not occur during terraform plan and apply.

## references
* Link to any supporting jira issues or helpful documentation to add some context (e.g. stackoverflow).
* Use `closes #123`, if this PR closes a Jira issue `#123`
