### PR TITLE
fix: Remove network interface deprecation

### DIFF
--- a/_example/linux-vm/example.tf
+++ b/_example/linux-vm/example.tf
@@ -35,7 +35,7 @@ module "vnet" {
 ##-----------------------------------------------------------------------------
 module "subnet" {
   source               = "clouddrove/subnet/azure"
-  version              = "1.1.0"
+  version              = "1.2.1"
   name                 = "app"
   environment          = "test"
   label_order          = ["name", "environment"]
@@ -88,25 +88,35 @@ module "security_group" {
 ## key-vault module call for disc encryption of virtual machine with cmk.
 #-----------------------------------------------------------------------------
 module "key_vault" {
-  source              = "clouddrove/key-vault/azure"
-  version             = "1.1.0"
-  name                = "app399433"
-  environment         = "test"
-  label_order         = ["name", "environment", ]
-  resource_group_name = module.resource_group.resource_group_name
-  location            = module.resource_group.resource_group_location
-  admin_objects_ids   = [data.azurerm_client_config.current_client_config.object_id]
-  subnet_id           = module.subnet.default_subnet_id[0]
-  virtual_network_id  = module.vnet.vnet_id
+  source  = "clouddrove/key-vault/azure"
+  version = "1.1.0"
+
+  name                        = "vae59d6058"
+  environment                 = "test"
+  label_order                 = ["name", "environment", ]
+  resource_group_name         = module.resource_group.resource_group_name
+  location                    = module.resource_group.resource_group_location
+  admin_objects_ids           = [data.azurerm_client_config.current_client_config.object_id]
+  virtual_network_id          = module.vnet.vnet_id
+  subnet_id                   = module.subnet.default_subnet_id[0]
+  enable_rbac_authorization   = true
+  enabled_for_disk_encryption = false
   #private endpoint
   enable_private_endpoint = false
-  ##RBAC
-  enable_rbac_authorization = true
-  network_acls = {
-    bypass         = "AzureServices"
-    default_action = "Deny"
-    ip_rules       = ["0.0.0.0/0"]
-  }
+  network_acls            = null
+  ########Following to be uncommnented only when using DNS Zone from different subscription along with existing DNS zone.
+
+  # diff_sub                                      = true
+  # alias                                         = ""
+  # alias_sub                                     = ""
+
+  #########Following to be uncommmented when using DNS zone from different resource group or different subscription.
+  # existing_private_dns_zone                     = ""
+  # existing_private_dns_zone_resource_group_name = ""
+
+  #### enable diagnostic setting
+  diagnostic_setting_enable  = false
+  log_analytics_workspace_id = module.log-analytics.workspace_id ## when diagnostic_setting_enable enable,  add log analytics workspace id
 }
 
 ##-----------------------------------------------------------------------------
@@ -151,7 +161,7 @@ module "virtual-machine" {
   public_ip_enabled = false
   ## Virtual Machine
   vm_size         = "Standard_B1s"
-  public_key      = "ssh-rsa AAAA"
+  public_key      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCbysTkkLhdRS5Zs5aZyGMqaDdoI98KpkOkM/jBpDsRiN/q8omnhgfbYGORj4MRbQhBMWmDxQPzB9vVOJ2oZTtLJonlxLZvkhW0s6KSEn3W5yCNuceDwr/01mjjTquVXCd9lDeBDstuZnx61PCAjzsuQQ3S9rDbIogZayZGcshnRN6qWNm7NNBb6MigMzsbE4QiJbtVNfjL8zbAKV3GlnO9HJ76FKfMdh8Qo9DALOrFyl7YSjOlUOUDyANuntaa9vPKB5qgSvraXcuBYg/zlrLmP/IyFmPiVfyJKK89vBTUskOP+e53gxs0q0W7W2xbQrbkcc7n4ivTDGi6VRRnf0tka3FP5GoRoHpz4WBgLUM2tATYl0TynusQO6mNGr5meS90A7RU18C6WVB56ggmFA10xL4ZHS+Xi0PrgHEgtEPP2qhqF/5IiakBVFOguVNX4BOoSAHpSXNAphpRdL19AfCarwL2Mue7lMz03KmiWFnC8K60Ma1XB7Do4GD/c/oUR4c="
   admin_username  = "ubuntu"
   caching         = "ReadWrite"
   disk_size_gb    = 30

--- a/_example/linux-vm/versions.tf
+++ b/_example/linux-vm/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.85.0"
+      version = ">=3.108.0"
     }
   }
 }

--- a/_example/windows-vm/example.tf
+++ b/_example/windows-vm/example.tf
@@ -35,7 +35,7 @@ module "vnet" {
 ##-----------------------------------------------------------------------------
 module "subnet" {
   source               = "clouddrove/subnet/azure"
-  version              = "1.1.0"
+  version              = "1.2.1"
   name                 = "app"
   environment          = "test"
   label_order          = ["name", "environment"]

--- a/_example/windows-vm/versions.tf
+++ b/_example/windows-vm/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.85.0"
+      version = "=3.108.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -15,15 +15,15 @@ module "labels" {
 ## Terraform resource to create a network interface for virtual machine.
 ##-----------------------------------------------------------------------------
 resource "azurerm_network_interface" "default" {
-  count                         = var.enabled ? var.machine_count : 0
-  name                          = var.vm_addon_name == null ? format("%s-nic-%s", module.labels.id, count.index + 1) : format("%s-nic-%s", module.labels.id, var.vm_addon_name)
-  resource_group_name           = var.resource_group_name
-  location                      = var.location
-  dns_servers                   = var.dns_servers
-  enable_ip_forwarding          = var.enable_ip_forwarding
-  enable_accelerated_networking = var.enable_accelerated_networking
-  internal_dns_name_label       = var.internal_dns_name_label
-  tags                          = module.labels.tags
+  count                          = var.enabled ? var.machine_count : 0
+  name                           = var.vm_addon_name == null ? format("%s-nic-%s", module.labels.id, count.index + 1) : format("%s-nic-%s", module.labels.id, var.vm_addon_name)
+  resource_group_name            = var.resource_group_name
+  location                       = var.location
+  dns_servers                    = var.dns_servers
+  ip_forwarding_enabled          = var.enable_ip_forwarding
+  accelerated_networking_enabled = var.enable_accelerated_networking
+  internal_dns_name_label        = var.internal_dns_name_label
+  tags                           = module.labels.tags
 
   ip_configuration {
     name                          = var.vm_addon_name == null ? format("%s-ip-config-%s", module.labels.id, count.index + 1) : format("%s-ip-config-%s", module.labels.id, var.vm_addon_name)

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.85.0"
+      version = ">=3.108.0"
     }
   }
 }


### PR DESCRIPTION
**_What_**
- Added accelerated_networking_enabled and `ip_forwarding_enabled` in place of `enable_accelerated_networking` and `enable_ip_forwarding`


**_Why_**
- `enable_accelerated_networking` and `enable_ip_forwarding` are now deprecated for azure network interface resource.
